### PR TITLE
Specify encoding to open method to conform to pylint update

### DIFF
--- a/e2e.py
+++ b/e2e.py
@@ -15,7 +15,7 @@ def asserts(input_dir: Path, output_dir: Path, quicklook_dir: Path, logger):
     # Print out bbox of one tile
     geojson_path = output_dir / "data.json"
 
-    with open(str(geojson_path)) as f:
+    with open(str(geojson_path), encoding="utf-8") as f:
         feature_collection = geojson.load(f)
 
     result_bbox = feature_collection.features[0].bbox

--- a/src/snap_polarimetry.py
+++ b/src/snap_polarimetry.py
@@ -121,6 +121,7 @@ class SNAPPolarimetry(ProcessingBlock):
 
         return self.safe_file_path(feature).joinpath("manifest.safe")
 
+    # pylint: disable=consider-using-with
     def process_template(self, substitutes: dict) -> str:
         """
         Processes the snap default template and substitutes
@@ -149,7 +150,7 @@ class SNAPPolarimetry(ProcessingBlock):
                 LOGGER.info(f"{key} will be discarded.")
                 self.revise_graph_xml(dst, key)
 
-        file_pointer = open(dst)
+        file_pointer = open(dst, encoding="utf-8")
         template = Template(file_pointer.read())
 
         return template.substitute(substitutes)


### PR DESCRIPTION
Weekly e2e tests are failing because of new pylint release (see [here](https://pypi.org/project/pylint/#history) and [here](http://pylint.pycqa.org/en/latest/whatsnew/2.10.html)). This is blocking any merging of branches.

The update expects any opening of json/geojson files to include encoding information.

Items:
* [ ] ...
* [x] Ran e2e and live-tests for updated blocks
