### PR TITLE
Replaces snap base image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM up42/up42-snap-py38
+FROM up42/up42-snap-py37
 
 ARG .
 ARG manifest


### PR DESCRIPTION
Replaces snap base image with up42-snap-py37 in order to be able to fix ticket UP-5678.

- I had to correct SRTM link on up42-snap-py38 and up42-snap-py37, but up42-snap-py38 won't build
- removed up42-snap-py38 in order to be able to fix this quickly, since a partner has been asking for this fix for over a week.

