### PR TITLE
UP-5678: Only bump version in order to rebuild the base image.

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-  "publicVersion": "2.2.4"
+  "publicVersion": "2.2.5"
 }


### PR DESCRIPTION
There are no changes to the original block code. Just bump version in order to rebuild the block and import the new base image already built (up42-snap-py38)