### PR TITLE
Bumps to 2.2.6

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-  "publicVersion": "2.2.5"
+  "publicVersion": "2.2.6"
 }


### PR DESCRIPTION
I need a new bump, because the current version on the platform (dev and prod) was already 2.2.5 (current version on repo was 2.2.4).